### PR TITLE
Fixed broken label on save form

### DIFF
--- a/template.js
+++ b/template.js
@@ -307,7 +307,7 @@ function setupSaveForm() {
 		fieldTmp = bfls('.save-form tr').eq(index).children('td').eq(1).html();
 		if (labelTmp.indexOf('<img') == -1 && fieldTmp) {
 			bfls('.save-form-bootstrap').append('<div class="form-group group'+ index +'"></div>');
-			bfls('.save-form-bootstrap .form-group.group'+index).append('<label for="'+ labelTmp +'">'+ labelTmp +'</label>');
+			bfls('.save-form-bootstrap .form-group.group'+index).append(labelTmp);
 			bfls('.save-form-bootstrap .form-group.group'+index).append(fieldTmp);
 		}
 	});


### PR DESCRIPTION
Save form was displaying broken label markup, something like:
`<label for="<label for="savename">Name</label>">Name</label>`

This was because the full label was being added as both for `for`
attribute and the label text.
